### PR TITLE
Fixes edwko/OuteTTS#4

### DIFF
--- a/outetts/v0_1/alignment.py
+++ b/outetts/v0_1/alignment.py
@@ -87,7 +87,7 @@ class CTCForcedAlignment:
             emission, _ = self.model(waveform.to(self.device))
 
         tokenized_transcript = [self.DICTIONARY[c] for word in transcript for c in word]
-        alignments, scores = self._align(emission, tokenized_transcript)
+        alignments, scores = self._align(emission[0:1, :, :], tokenized_transcript)
         word_spans = self._extract_world_level(alignments, scores, transcript)
         num_frames = emission.size(1)
 


### PR DESCRIPTION
This fix is to guarantee that force-align always receives mono audio to process.