### PR TITLE
~4.6x speedup, Huge memory optimizations: EXL2 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ OuteTTS is an experimental text-to-speech model that uses a pure language modeli
 pip install outetts
 ```
 
-**Important:** For GGUF support, you must manually install `llama-cpp-python` first.
+**Important:**
+For GGUF support, you must manually install `llama-cpp-python` first.
+For EXL2 support, you must manually install `exllamav2` and `flash-attn` first.
 
 Visit https://github.com/abetlen/llama-cpp-python for specific installation instructions
 
@@ -73,10 +75,24 @@ model_config = outetts.GGUFModelConfig_v1(
     model_path="local/path/to/model.gguf",
     language="en", # Supported languages in v0.2: en, zh, ja, ko
     n_gpu_layers=0,
+    max_length=4096,
 )
 
 # Initialize the GGUF interface
 interface = outetts.InterfaceGGUF(model_version="0.2", cfg=model_config)
+```
+
+### Using EXL2 Model
+```python
+# Configure the EXL2 model
+model_config = outetts.EXL2ModelConfig_v1(
+    model_path="local/path/to/model",
+    language="en", # Supported languages in v0.2: en, zh, ja, ko
+    max_length=4096,
+)
+
+# Initialize the EXL2 interface
+interface = outetts.InterfaceEXL2(model_version="0.2", cfg=model_config)
 ```
 
 ### Configure the model with bfloat16 and flash attention

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ interface = outetts.InterfaceGGUF(model_version="0.2", cfg=model_config)
 model_config = outetts.EXL2ModelConfig_v1(
     model_path="local/path/to/model",
     language="en", # Supported languages in v0.2: en, zh, ja, ko
-    max_length=4096,
 )
 
 # Initialize the EXL2 interface

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ model_config = outetts.GGUFModelConfig_v1(
     model_path="local/path/to/model.gguf",
     language="en", # Supported languages in v0.2: en, zh, ja, ko
     n_gpu_layers=0,
-    max_length=4096,
 )
 
 # Initialize the GGUF interface

--- a/outetts/__init__.py
+++ b/outetts/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0" 
+__version__ = "0.2.1" 
 
 from .interface import InterfaceHF, InterfaceGGUF, InterfaceEXL2, display_available_models
 from .interface import HFModelConfig_v1, GGUFModelConfig_v1, EXL2ModelConfig_v1

--- a/outetts/__init__.py
+++ b/outetts/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.2.0" 
 
-from .interface import InterfaceHF, InterfaceGGUF, display_available_models
-from .interface import HFModelConfig_v1, GGUFModelConfig_v1
+from .interface import InterfaceHF, InterfaceGGUF, InterfaceEXL2, display_available_models
+from .interface import HFModelConfig_v1, GGUFModelConfig_v1, EXL2ModelConfig_v1
 from .version.v1.alignment import CTCForcedAlignment

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -84,7 +84,7 @@ def InterfaceHF(
 
     interface_class = config["hf_interface"]
 
-    check_max_length(cfg.max_length, config["max_length"])
+    #check_max_length(cfg.cache_size, config["max_length"])
 
     return interface_class(cfg)
 
@@ -117,7 +117,7 @@ def InterfaceGGUF(
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
 
-    check_max_length(cfg.max_length, config["max_length"])
+    #check_max_length(cfg.cache_size, config["max_length"])
 
     interface_class = config["gguf_interface"]
     return interface_class(cfg)
@@ -148,7 +148,7 @@ def InterfaceEXL2(
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
 
-    check_max_length(cfg.max_length, config["max_length"])
+    #check_max_length(cfg.cache_size, config["max_length"])
 
     interface_class = config["exl2_interface"]
     return interface_class(cfg)

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -113,7 +113,7 @@ def InterfaceGGUF(
 def InterfaceEXL2(
         model_version: str,
         cfg: EXL2ModelConfig_v1
-    ) -> _InterfaceGGUF_v1:
+    ) -> _InterfaceEXL2_v1:
     """
     Creates and returns a GGUF model interface for OuteTTS.
 

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -15,6 +15,7 @@ MODEL_CONFIGS = {
         "languages": ["en"],
         "hf_interface": _InterfaceHF_v1,
         "gguf_interface": _InterfaceGGUF_v1,
+        "max_length": 4096
     },
     "0.2": {
         "tokenizer": "OuteAI/OuteTTS-0.2-500M",
@@ -24,6 +25,7 @@ MODEL_CONFIGS = {
         "hf_interface": _InterfaceHF_v1,
         "gguf_interface": _InterfaceGGUF_v1,
         "exl2_interface": _InterfaceEXL2_v1,
+        "max_length": 4096
     },
 }
 
@@ -47,6 +49,12 @@ def get_model_config(version: str):
     if version not in MODEL_CONFIGS:
         raise ValueError(f"Unsupported model version '{version}'. Supported versions are: {list(MODEL_CONFIGS.keys())}")
     return MODEL_CONFIGS[version]
+
+def check_max_length(max_lenght: int, model_max_length: int):
+    if max_lenght is None:
+        raise ValueError("max_length must be specified.")
+    if max_lenght > model_max_length:
+        raise ValueError(f"Requested max_length ({max_lenght}) exceeds the maximum supported length ({model_max_length}).")
 
 def InterfaceHF(
         model_version: str,
@@ -75,6 +83,8 @@ def InterfaceHF(
     cfg.languages = languages
 
     interface_class = config["hf_interface"]
+
+    check_max_length(cfg.max_length, config["max_length"])
 
     return interface_class(cfg)
 
@@ -107,6 +117,8 @@ def InterfaceGGUF(
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
 
+    check_max_length(cfg.max_length, config["max_length"])
+
     interface_class = config["gguf_interface"]
     return interface_class(cfg)
 
@@ -135,6 +147,8 @@ def InterfaceEXL2(
     if cfg.language not in languages:
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
+
+    check_max_length(cfg.max_length, config["max_length"])
 
     interface_class = config["exl2_interface"]
     return interface_class(cfg)

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -1,8 +1,10 @@
 import torch
 from .version.v1.interface import InterfaceHF as _InterfaceHF_v1
 from .version.v1.interface import InterfaceGGUF as _InterfaceGGUF_v1
+from .version.v1.interface import InterfaceEXL2 as _InterfaceEXL2_v1
 from .version.v1.interface import HFModelConfig as HFModelConfig_v1
 from .version.v1.interface import GGUFModelConfig as GGUFModelConfig_v1
+from .version.v1.interface import EXL2ModelConfig as EXL2ModelConfig_v1
 from loguru import logger
 
 MODEL_CONFIGS = {
@@ -21,6 +23,7 @@ MODEL_CONFIGS = {
         "languages": ["en", "ja", "ko", "zh"],
         "hf_interface": _InterfaceHF_v1,
         "gguf_interface": _InterfaceGGUF_v1,
+        "exl2_interface": _InterfaceEXL2_v1,
     },
 }
 
@@ -105,4 +108,33 @@ def InterfaceGGUF(
     cfg.languages = languages
 
     interface_class = config["gguf_interface"]
+    return interface_class(cfg)
+
+def InterfaceEXL2(
+        model_version: str,
+        cfg: EXL2ModelConfig_v1
+    ) -> _InterfaceGGUF_v1:
+    """
+    Creates and returns a GGUF model interface for OuteTTS.
+
+    Parameters
+    ----------
+    model_version : str
+        Version identifier for the model to be loaded
+    cfg : EXL2ModelConfig_v1
+        Configuration object containing parameters
+
+    Returns
+    -------
+    An instance of interface based on the specified version.
+    """
+
+    config = get_model_config(model_version)
+    cfg.tokenizer_path = cfg.tokenizer_path or config["tokenizer"]
+    languages = config["languages"]
+    if cfg.language not in languages:
+        raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
+    cfg.languages = languages
+
+    interface_class = config["exl2_interface"]
     return interface_class(cfg)

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -15,7 +15,7 @@ MODEL_CONFIGS = {
         "languages": ["en"],
         "hf_interface": _InterfaceHF_v1,
         "gguf_interface": _InterfaceGGUF_v1,
-        "max_length": 4096
+        "max_seq_length": 4096
     },
     "0.2": {
         "tokenizer": "OuteAI/OuteTTS-0.2-500M",
@@ -25,7 +25,7 @@ MODEL_CONFIGS = {
         "hf_interface": _InterfaceHF_v1,
         "gguf_interface": _InterfaceGGUF_v1,
         "exl2_interface": _InterfaceEXL2_v1,
-        "max_length": 4096
+        "max_seq_length": 4096
     },
 }
 
@@ -50,11 +50,11 @@ def get_model_config(version: str):
         raise ValueError(f"Unsupported model version '{version}'. Supported versions are: {list(MODEL_CONFIGS.keys())}")
     return MODEL_CONFIGS[version]
 
-def check_max_length(max_length: int, model_max_length: int):
-    if max_length is None:
-        raise ValueError("max_length must be specified.")
-    if max_length > model_max_length:
-        raise ValueError(f"Requested max_length ({max_length}) exceeds the maximum supported length ({model_max_length}).")
+def check_max_length(max_seq_length: int, model_max_seq_length: int):
+    if max_seq_length is None:
+        raise ValueError("max_seq_length must be specified.")
+    if max_seq_length > model_max_seq_length:
+        raise ValueError(f"Requested max_seq_length ({max_seq_length}) exceeds the maximum supported length ({model_max_seq_length}).")
 
 def InterfaceHF(
         model_version: str,
@@ -84,7 +84,7 @@ def InterfaceHF(
 
     interface_class = config["hf_interface"]
 
-    #check_max_length(cfg.cache_size, config["max_length"])
+    check_max_length(cfg.max_seq_length, config["max_seq_length"])
 
     return interface_class(cfg)
 
@@ -117,7 +117,7 @@ def InterfaceGGUF(
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
 
-    #check_max_length(cfg.cache_size, config["max_length"])
+    check_max_length(cfg.max_seq_length, config["max_seq_length"])
 
     interface_class = config["gguf_interface"]
     return interface_class(cfg)
@@ -148,7 +148,7 @@ def InterfaceEXL2(
         raise ValueError(f"Language '{cfg.language}' is not supported by model version '{model_version}'. Supported languages are: {languages}")
     cfg.languages = languages
 
-    #check_max_length(cfg.cache_size, config["max_length"])
+    check_max_length(cfg.max_seq_length, config["max_seq_length"])
 
     interface_class = config["exl2_interface"]
     return interface_class(cfg)

--- a/outetts/interface.py
+++ b/outetts/interface.py
@@ -50,11 +50,11 @@ def get_model_config(version: str):
         raise ValueError(f"Unsupported model version '{version}'. Supported versions are: {list(MODEL_CONFIGS.keys())}")
     return MODEL_CONFIGS[version]
 
-def check_max_length(max_lenght: int, model_max_length: int):
-    if max_lenght is None:
+def check_max_length(max_length: int, model_max_length: int):
+    if max_length is None:
         raise ValueError("max_length must be specified.")
-    if max_lenght > model_max_length:
-        raise ValueError(f"Requested max_length ({max_lenght}) exceeds the maximum supported length ({model_max_length}).")
+    if max_length > model_max_length:
+        raise ValueError(f"Requested max_length ({max_length}) exceeds the maximum supported length ({model_max_length}).")
 
 def InterfaceHF(
         model_version: str,

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -224,8 +224,8 @@ class InterfaceHF:
     def check_generation_max_length(self, max_length):
         if max_length is None:
             raise ValueError("max_length must be specified.")
-        if max_length > self.config.max_length:
-            raise ValueError(f"Requested max_length ({max_length}) exceeds the maximum supported length ({self.config.max_length}).")
+        if max_length > self.config.cache_size:
+            raise ValueError(f"Requested max_length ({max_length}) exceeds the current allocation ({self.config.max_length}).")
 
     def generate(
             self, 

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -63,6 +63,7 @@ class HFModelConfig:
     dtype: torch.dtype = None
     additional_model_config: dict = field(default_factory=dict)
     wavtokenizer_model_path: str = None
+    cache_size: int = 4096
 
 @dataclass
 class GGUFModelConfig(HFModelConfig):

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -226,7 +226,8 @@ class InterfaceHF:
             speaker: dict = None, 
             temperature: float = 0.1, 
             repetition_penalty: float = 1.1, 
-            max_length: int = 4096
+            max_length: int = 4096,
+            additional_gen_config={},
         ) -> ModelOutput:
         input_ids = self.prepare_prompt(text, speaker)
         if self.verbose:
@@ -238,7 +239,8 @@ class InterfaceHF:
             config=GenerationConfig(
                 temperature=temperature,
                 repetition_penalty=repetition_penalty,
-                max_length=max_length
+                max_length=max_length,
+                additional_gen_config=additional_gen_config,
             )
         )
         audio = self.get_audio(output[input_ids.size()[-1]:])
@@ -282,6 +284,7 @@ class InterfaceGGUF(InterfaceHF):
             temperature: float = 0.1, 
             repetition_penalty: float = 1.1,
             max_length = None,
+            additional_gen_config = {},
         ) -> ModelOutput:
         input_ids = self.prepare_prompt(text, speaker)
         if self.verbose:
@@ -297,6 +300,7 @@ class InterfaceGGUF(InterfaceHF):
                 temperature=temperature,
                 max_length=config.max_length,
                 repetition_penalty=repetition_penalty,
+                additional_gen_config=additional_gen_config,
             )
         )
         audio = self.get_audio(output)
@@ -339,6 +343,7 @@ class InterfaceEXL2(InterfaceHF):
             temperature: float = 0.1, 
             repetition_penalty: float = 1.1,
             max_length = None,
+            additional_gen_config = {},
         ) -> ModelOutput:
         input_ids = self.prepare_prompt(text, speaker)
         if self.verbose:
@@ -353,6 +358,7 @@ class InterfaceEXL2(InterfaceHF):
             config=GenerationConfig(
                 temperature=temperature,
                 repetition_penalty=repetition_penalty,
+                additional_gen_config=additional_gen_config,
             )
         )
         audio = self.get_audio(output)

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -63,7 +63,6 @@ class HFModelConfig:
     dtype: torch.dtype = None
     additional_model_config: dict = field(default_factory=dict)
     wavtokenizer_model_path: str = None
-    cache_size: int = 4096
 
 @dataclass
 class GGUFModelConfig(HFModelConfig):

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -71,7 +71,7 @@ class GGUFModelConfig(HFModelConfig):
 
 @dataclass
 class EXL2ModelConfig(HFModelConfig):
-    max_length: int = 4096
+    pass
 
 @dataclass
 class ModelOutput:
@@ -292,7 +292,7 @@ class InterfaceGGUF(InterfaceHF):
             logger.info("Generating audio...")
         
         if max_length != None:
-            raise ValueError("max_length must be set in the model config during model creation for GGUF and EXL2 models.")
+            raise ValueError("max_length must be set in the model config during model creation for GGUF models.")
         
         output = self.model.generate(
             input_ids=input_ids,
@@ -328,7 +328,6 @@ class InterfaceEXL2(InterfaceHF):
         self.prompt_processor = PromptProcessor(config.tokenizer_path, self.languages)
         self.model = EXL2Model(
             model_path=config.model_path,
-            max_length=config.max_length,
             additional_model_config=config.additional_model_config
         )
 
@@ -342,7 +341,7 @@ class InterfaceEXL2(InterfaceHF):
             speaker: dict = None, 
             temperature: float = 0.1, 
             repetition_penalty: float = 1.1,
-            max_length = None,
+            max_length = 4096,
             additional_gen_config = {},
         ) -> ModelOutput:
         input_ids = self.prepare_prompt(text, speaker)
@@ -350,14 +349,12 @@ class InterfaceEXL2(InterfaceHF):
             logger.info(f"Input tokens: {len(input_ids)}")
             logger.info("Generating audio...")
         
-        if max_length != None:
-            raise ValueError("max_length must be set in the model config during model creation for GGUF and EXL2 models.")
-        
         output = self.model.generate(
             input_ids=input_ids,
             config=GenerationConfig(
                 temperature=temperature,
                 repetition_penalty=repetition_penalty,
+                max_length=max_length,
                 additional_gen_config=additional_gen_config,
             )
         )

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -63,15 +63,16 @@ class HFModelConfig:
     dtype: torch.dtype = None
     additional_model_config: dict = field(default_factory=dict)
     wavtokenizer_model_path: str = None
-    max_length: int = 4096
+    cache_size: int = 4096
 
 @dataclass
 class GGUFModelConfig(HFModelConfig):
     n_gpu_layers: int = 0
+    cache_size: int = 4096
 
 @dataclass
 class EXL2ModelConfig(HFModelConfig):
-    pass
+    cache_size: int = None
 
 @dataclass
 class ModelOutput:
@@ -279,7 +280,7 @@ class InterfaceGGUF(InterfaceHF):
         self.model = GGUFModel(
             model_path=config.model_path,
             n_gpu_layers=config.n_gpu_layers,
-            max_length=config.max_length,
+            cache_size=config.cache_size,
             additional_model_config=config.additional_model_config
         )
 
@@ -338,7 +339,7 @@ class InterfaceEXL2(InterfaceHF):
         self.prompt_processor = PromptProcessor(config.tokenizer_path, self.languages)
         self.model = EXL2Model(
             model_path=config.model_path,
-            max_length=config.max_length,
+            cache_size=config.cache_size,
             additional_model_config=config.additional_model_config,
         )
 

--- a/outetts/version/v1/interface.py
+++ b/outetts/version/v1/interface.py
@@ -225,7 +225,7 @@ class InterfaceHF:
     def check_generation_max_length(self, max_length):
         if max_length is None:
             raise ValueError("max_length must be specified.")
-        if max_length > self.config.cache_size:
+        if self.config.cache_size and max_length > self.config.cache_size:
             raise ValueError(f"Requested max_length ({max_length}) exceeds the current allocation ({self.config.max_length}).")
 
     def generate(

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -59,7 +59,7 @@ class GGUFModel:
             self,
             model_path: str,
             n_gpu_layers: int = 0,
-            max_length: int = 4096,
+            cache_size: int = 4096,
             additional_model_config: dict = {}
     ) -> None:
         
@@ -69,7 +69,7 @@ class GGUFModel:
                 "To use the GGUF model you must install llama cpp python manually."
             )
 
-        additional_model_config["n_ctx"] = max_length
+        additional_model_config["n_ctx"] = cache_size
         self.model = Llama(
             model_path=model_path,
             n_gpu_layers=n_gpu_layers,
@@ -95,7 +95,7 @@ class EXL2Model:
     def __init__(
             self,
             model_path: str,
-            max_length: int,
+            cache_size: int,
             additional_model_config: dict = {},
     ) -> None:
         
@@ -107,7 +107,7 @@ class EXL2Model:
         config = ExLlamaV2Config(model_path)
         config.arch_compat_overrides()
         self.model = ExLlamaV2(config)
-        self.cache = ExLlamaV2Cache(self.model, max_seq_len=config.max_seq_len, lazy=True)
+        self.cache = ExLlamaV2Cache(self.model, max_seq_len=cache_size or config.max_seq_len, lazy=True)
         self.model.load_autosplit(self.cache, progress=True)
         self.tokenizer = ExLlamaV2Tokenizer(config)
     

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -1,19 +1,29 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import torch
 from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 try:
     from llama_cpp import Llama, llama_token_is_eog
-    _GGUF_AVAILABLE = True
 except ImportError:
     _GGUF_AVAILABLE = False
+else:
+    _GGUF_AVAILABLE = True
+
+try:
+    from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Cache, ExLlamaV2Tokenizer
+    from exllamav2.generator import ExLlamaV2DynamicGenerator, ExLlamaV2DynamicJob, ExLlamaV2Sampler
+except ImportError:
+    _EXL2_AVAILABLE = False
+else:
+    _EXL2_AVAILABLE = True
 
 @dataclass
 class GenerationConfig:
     temperature: float = 0.1
     repetition_penalty: float = 1.1
     max_length: int = 4096
+    additional_gen_config: dict = field(default_factory=lambda: {})
 
 class HFModel:
     def __init__(
@@ -42,7 +52,8 @@ class HFModel:
             max_length=config.max_length,
             temperature=config.temperature,
             repetition_penalty=config.repetition_penalty,
-            do_sample=True
+            do_sample=True,
+            **config.additional_gen_config,
         )[0].tolist()
 
 class GGUFModel:
@@ -50,6 +61,7 @@ class GGUFModel:
             self,
             model_path: str,
             n_gpu_layers: int = 0,
+            max_length: int = 4096,
             additional_model_config: dict = {}
     ) -> None:
         
@@ -59,7 +71,7 @@ class GGUFModel:
                 "To use the GGUF model you must install llama cpp python manually."
             )
 
-        additional_model_config["n_ctx"] = 4096
+        additional_model_config["n_ctx"] = max_length
         self.model = Llama(
             model_path=model_path,
             n_gpu_layers=n_gpu_layers,
@@ -71,11 +83,57 @@ class GGUFModel:
         for token in self.model.generate(
             input_ids,
             temp=config.temperature,
-            repeat_penalty=config.repetition_penalty
+            repeat_penalty=config.repetition_penalty,
+            **config.additional_gen_config,
         ):
             tokens.append(token)
             if (llama_token_is_eog(self.model._model.model, token) or 
                 len(tokens) >= config.max_length):
                 break
 
+        return tokens
+
+class EXL2Model:
+    def __init__(
+            self,
+            model_path: str,
+            max_length: int = 4096,
+            additional_model_config: dict = {}
+    ) -> None:
+        
+        if not _EXL2_AVAILABLE:
+            raise ImportError(
+                "exllamav2 python module not found."
+                "To use the GGUF model you must install exllamav2 manually."
+            )
+        config = ExLlamaV2Config(model_path)
+        config.arch_compat_overrides()
+        self.model = ExLlamaV2(config)
+        # Room for improvement: Cache is hardcoded to qwen-2.5-0.5B max seq len
+        self.cache = ExLlamaV2Cache(self.model, max_seq_len=32768, lazy=True)
+        self.model.load_autosplit(self.cache, progress=True)
+        self.tokenizer = ExLlamaV2Tokenizer(config)
+        self.max_length = max_length
+    
+    def generate(self, input_ids: list[int], config: GenerationConfig) -> list[int]:
+        generator = ExLlamaV2DynamicGenerator(
+            model = self.model,
+            cache = self.cache,
+            tokenizer = self.tokenizer,
+            gen_settings = ExLlamaV2Sampler.Settings(token_repetition_penalty=config.repetition_penalty, temperature=config.temperature, **config.additional_gen_config)
+        )
+        job = ExLlamaV2DynamicJob(input_ids=torch.tensor([input_ids]), max_new_tokens=self.max_length)
+        generator.enqueue(job)
+        eos = False
+        tokens = []
+        while not eos:
+            results = generator.iterate()
+            # Only batches one at a time. Has room for improvement.
+            for result in results:
+                assert result["job"] == job
+                if result["stage"] == "streaming":
+                    tokens.append(int(result.get("token_ids", "")[0][0]))
+                    if tokens[-1] == 151645:
+                        eos = True
+        #print(tokens)
         return tokens

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -97,7 +97,6 @@ class EXL2Model:
     def __init__(
             self,
             model_path: str,
-            max_length: int = 4096,
             additional_model_config: dict = {}
     ) -> None:
         
@@ -113,16 +112,16 @@ class EXL2Model:
         self.cache = ExLlamaV2Cache(self.model, max_seq_len=32768, lazy=True)
         self.model.load_autosplit(self.cache, progress=True)
         self.tokenizer = ExLlamaV2Tokenizer(config)
-        self.max_length = max_length
     
     def generate(self, input_ids: list[int], config: GenerationConfig) -> list[int]:
         generator = ExLlamaV2DynamicGenerator(
             model = self.model,
             cache = self.cache,
+            max_length: int = 4096,
             tokenizer = self.tokenizer,
             gen_settings = ExLlamaV2Sampler.Settings(token_repetition_penalty=config.repetition_penalty, temperature=config.temperature, **config.additional_gen_config)
         )
-        job = ExLlamaV2DynamicJob(input_ids=torch.tensor([input_ids]), max_new_tokens=self.max_length)
+        job = ExLlamaV2DynamicJob(input_ids=torch.tensor([input_ids]), max_new_tokens=max_length)
         generator.enqueue(job)
         eos = False
         tokens = []

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -117,11 +117,10 @@ class EXL2Model:
         generator = ExLlamaV2DynamicGenerator(
             model = self.model,
             cache = self.cache,
-            max_length: int = 4096,
             tokenizer = self.tokenizer,
             gen_settings = ExLlamaV2Sampler.Settings(token_repetition_penalty=config.repetition_penalty, temperature=config.temperature, **config.additional_gen_config)
         )
-        job = ExLlamaV2DynamicJob(input_ids=torch.tensor([input_ids]), max_new_tokens=max_length)
+        job = ExLlamaV2DynamicJob(input_ids=torch.tensor([input_ids]), max_new_tokens=config.max_length)
         generator.enqueue(job)
         eos = False
         tokens = []

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -59,7 +59,7 @@ class GGUFModel:
             self,
             model_path: str,
             n_gpu_layers: int = 0,
-            cache_size: int = 4096,
+            max_seq_length: int = 4096,
             additional_model_config: dict = {}
     ) -> None:
         
@@ -69,7 +69,7 @@ class GGUFModel:
                 "To use the GGUF model you must install llama cpp python manually."
             )
 
-        additional_model_config["n_ctx"] = cache_size
+        additional_model_config["n_ctx"] = max_seq_length
         self.model = Llama(
             model_path=model_path,
             n_gpu_layers=n_gpu_layers,
@@ -95,7 +95,7 @@ class EXL2Model:
     def __init__(
             self,
             model_path: str,
-            cache_size: int,
+            max_seq_length: int,
             additional_model_config: dict = {},
     ) -> None:
         
@@ -104,10 +104,11 @@ class EXL2Model:
                 "exllamav2 python module not found."
                 "To use the EXL2 model you must install exllamav2 manually."
             )
+
         config = ExLlamaV2Config(model_path)
         config.arch_compat_overrides()
         self.model = ExLlamaV2(config)
-        self.cache = ExLlamaV2Cache(self.model, max_seq_len=cache_size or config.max_seq_len, lazy=True)
+        self.cache = ExLlamaV2Cache(self.model, max_seq_len=config.max_seq_len, lazy=True)
         self.model.load_autosplit(self.cache, progress=True)
         self.tokenizer = ExLlamaV2Tokenizer(config)
     

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -107,7 +107,7 @@ class EXL2Model:
         config = ExLlamaV2Config(model_path)
         config.arch_compat_overrides()
         self.model = ExLlamaV2(config)
-        self.cache = ExLlamaV2Cache(self.model, max_seq_len=max_length*2, lazy=True)
+        self.cache = ExLlamaV2Cache(self.model, max_seq_len=config.max_seq_len, lazy=True)
         self.model.load_autosplit(self.cache, progress=True)
         self.tokenizer = ExLlamaV2Tokenizer(config)
     

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -133,7 +133,7 @@ class EXL2Model:
                 assert result["job"] == job
                 if result["stage"] == "streaming":
                     tokens.append(int(result.get("token_ids", "")[0][0]))
-                    if tokens[-1] == 151645:
+                    if tokens[-1] == self.tokenizer.eos_token_id:
                         eos = True
         #print(tokens)
         return tokens

--- a/outetts/version/v1/model.py
+++ b/outetts/version/v1/model.py
@@ -6,14 +6,14 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 try:
     from llama_cpp import Llama, llama_token_is_eog
     _GGUF_AVAILABLE = True
-except:
+except ImportError:
     _GGUF_AVAILABLE = False
 
 try:
     from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Cache, ExLlamaV2Tokenizer
     from exllamav2.generator import ExLlamaV2DynamicGenerator, ExLlamaV2DynamicJob, ExLlamaV2Sampler
     _EXL2_AVAILABLE = True
-except:
+except ImportError:
     _EXL2_AVAILABLE = False
 
 @dataclass

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt', 'r', encoding='utf-8') as fh:
 
 setup(
     name='outetts',
-    version='0.2.0',
+    version='0.2.1',
     packages=find_packages(),
     install_requires=install_requires,
     author='OuteAI',


### PR DESCRIPTION
This adds EXL2 as a backend as well as slight refactoring to the original backend code. I now achieve the example code in 2.76 seconds versus 12.6 seconds from the HF implementation (measuring only model gen, not model load), as well as much lower memory requirements. Crosses the real time factor threshold.

HF:

https://github.com/user-attachments/assets/384734b4-14a1-4564-b5e5-9298a8d4da71

EXL2:

https://github.com/user-attachments/assets/b299bfb0-e141-4f58-b546-9f107127fdf4

Example code:

- First download [my checkpoint](https://huggingface.co/imnotednamode/OuteTTS-0.2-500M-exl2-b6.0-hb8) or make your own

```python
import outetts

model_config = outetts.EXL2ModelConfig_v1(
    model_path="OuteTTS-0.2-500M-exl2-b6.0-hb8",
    language="en",  # Supported languages in v0.2: en, zh, ja, ko
    max_length=4096,
)
interface = outetts.InterfaceEXL2(model_version="0.2", cfg=model_config)
speaker = interface.load_default_speaker(name="male_1")

output = interface.generate(
    text="Speech synthesis is the artificial production of human speech. A computer system used for this purpose is called a speech synthesizer, and it can be implemented in software or hardware products.",
    temperature=0.1,
    repetition_penalty=1.1,
    speaker=speaker,
)

output.save("output.wav")
```