### PR TITLE
Add default backend for playing sound and support `.play()` without a…

### DIFF
--- a/outetts/version/playback.py
+++ b/outetts/version/playback.py
@@ -54,7 +54,7 @@ class ModelOutput:
     def _invalid_backend(self):
         logger.warning(f"Invalid backend selected!")
 
-    def play(self, backend: str):
+    def play(self, backend="pygame"):
         """
         backend: str -> "sounddevice", "pygame"
         """


### PR DESCRIPTION
…dditional parameters

Currently the streaming interface use `.play()` which requires a default backend.